### PR TITLE
add @types/minimist so that build step passes

### DIFF
--- a/packages/xstate-compiled/package.json
+++ b/packages/xstate-compiled/package.json
@@ -32,6 +32,7 @@
     "@types/glob": "^7.1.3",
     "@types/handlebars-helpers": "^0.5.2",
     "@types/jest": "^26.0.10",
+    "@types/minimist": "^1.2.0",
     "@types/node": "^14.0.14",
     "@xstate/react": "^0.8.1",
     "jest": "^26.4.0",


### PR DESCRIPTION
when running the install command in packages/xstate-compiled it fails with:

error TS7016: Could not find a declaration file for module 'minimist'.

adding @types/minimist fixes the problem.