### PR TITLE
Fix bug on first-time startup

### DIFF
--- a/.changeset/sharp-squids-tie.md
+++ b/.changeset/sharp-squids-tie.md
@@ -1,0 +1,5 @@
+---
+'xstate-codegen': patch
+---
+
+Fixed a bug where, when run for the first time, the codegen tool would fail because rollup would see no .js files in the @xstate/compiled node_module directory

--- a/packages/xstate-compiled/src/__tests__/printToFile.test.ts
+++ b/packages/xstate-compiled/src/__tests__/printToFile.test.ts
@@ -1,5 +1,5 @@
 import { Machine } from 'xstate';
-import { getFileTexts } from '../printToFile';
+import { getDeclarationFileTexts } from '../printToFile';
 import { introspectMachine } from '../introspectMachine';
 
 test('That printToFile matches a snapshot test', () => {
@@ -33,7 +33,7 @@ test('That printToFile matches a snapshot test', () => {
     },
   });
 
-  const files = getFileTexts({
+  const files = getDeclarationFileTexts({
     'index.js': { id: 'something', ...introspectMachine(machine) },
   });
 

--- a/packages/xstate-compiled/src/index.ts
+++ b/packages/xstate-compiled/src/index.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import minimist from 'minimist';
 import { introspectMachine } from './introspectMachine';
 import { extractMachines } from './extractMachines';
-import { printToFile } from './printToFile';
+import { printToFile, printJsFiles } from './printToFile';
 
 const { _: arrayArgs, ...objectArgs } = minimist(process.argv.slice(2));
 
@@ -68,6 +68,7 @@ gaze(pattern, {}, async function(err, watcher) {
     if (!code.includes('@xstate/compiled')) {
       return;
     }
+    printJsFiles();
     const machines = await extractMachines(filePath);
     if (machines.length === 0) {
       return;

--- a/packages/xstate-compiled/src/index.ts
+++ b/packages/xstate-compiled/src/index.ts
@@ -61,6 +61,7 @@ gaze(pattern, {}, async function(err, watcher) {
     process.exit(1);
   }
 
+  printJsFiles();
   console.clear();
 
   const addToCache = async (filePath: string) => {
@@ -68,7 +69,6 @@ gaze(pattern, {}, async function(err, watcher) {
     if (!code.includes('@xstate/compiled')) {
       return;
     }
-    printJsFiles();
     const machines = await extractMachines(filePath);
     if (machines.length === 0) {
       return;


### PR DESCRIPTION
Fixed a bug where, when run for the first time, running the codegen tool would fail because rollup would see no .js files in the @xstate/compiled node_module directory