### PR TITLE
Bug rollup external file

### DIFF
--- a/.changeset/gorgeous-eagles-retire.md
+++ b/.changeset/gorgeous-eagles-retire.md
@@ -1,0 +1,5 @@
+---
+'xstate-codegen': patch
+---
+
+fixed a bug where rollup was converting relative file paths to absolute and then treating the files as external causing the watched files to fail with 'Unexpected Syntax' errors.

--- a/packages/xstate-compiled/src/extractMachines.ts
+++ b/packages/xstate-compiled/src/extractMachines.ts
@@ -248,7 +248,7 @@ export const extractMachines = async (
 
   const build = await rollup({
     input: resolvedFilePath,
-    external: (id) => !id.startsWith('.'),
+    external: (id) => !/^(\.|\/|\w:)/.test(id),
     plugins: [
       nodeResolvePlugin({
         extensions,


### PR DESCRIPTION
related to: #16 this fixes the issue of rollup treating absolute paths as external.
credit to @rjdestigter for figuring out the issue and @mattpocock for providing the fix used in this pr.