### PR TITLE
Improved type checking speed in VSCode by rimraffing the .d.ts files before regenerating them

### DIFF
--- a/.changeset/nervous-toes-roll.md
+++ b/.changeset/nervous-toes-roll.md
@@ -1,0 +1,5 @@
+---
+"xstate-codegen": patch
+---
+
+Improved type checking speed in VSCode by rimraffing the .d.ts files before regenerating them

--- a/packages/xstate-compiled/examples/fetchMachine.machine.ts
+++ b/packages/xstate-compiled/examples/fetchMachine.machine.ts
@@ -13,7 +13,7 @@ type Event =
   | { type: 'CANCEL' }
   | { type: 'done.invoke.makeFetch'; data: Data };
 
-const machine = Machine<Context, Event, 'wowMachine'>({
+const machine = Machine<Context, Event, 'fetchMachine'>({
   initial: 'idle',
   states: {
     idle: {

--- a/packages/xstate-compiled/examples/fetchMachine.machine.ts
+++ b/packages/xstate-compiled/examples/fetchMachine.machine.ts
@@ -13,7 +13,7 @@ type Event =
   | { type: 'CANCEL' }
   | { type: 'done.invoke.makeFetch'; data: Data };
 
-const machine = Machine<Context, Event, 'fetchMachine'>({
+const machine = Machine<Context, Event, 'wowMachine'>({
   initial: 'idle',
   states: {
     idle: {
@@ -22,10 +22,12 @@ const machine = Machine<Context, Event, 'fetchMachine'>({
       },
     },
     pending: {
-      invoke: {
-        src: 'makeFetch',
-        onDone: 'success',
-      },
+      invoke: [
+        {
+          src: 'makeFetch',
+          onDone: 'success',
+        },
+      ],
     },
     success: {
       entry: ['celebrate'],

--- a/packages/xstate-compiled/package.json
+++ b/packages/xstate-compiled/package.json
@@ -20,10 +20,12 @@
     "handlebars": "^4.7.6",
     "handlebars-helpers": "^0.10.0",
     "pkg-up": "^3.1.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.26.3",
     "xstate": "^4.12.0"
   },
   "devDependencies": {
+    "@types/rimraf": "^3.0.0",
     "@changesets/cli": "^2.9.2",
     "@types/babel-plugin-macros": "^2.8.2",
     "@types/babel__core": "^7.1.9",
@@ -36,7 +38,8 @@
     "@xstate/react": "^0.8.1",
     "jest": "^26.4.0",
     "ts-jest": "^26.2.0",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "react": "16.13.1"
   },
   "scripts": {
     "local-link": "yarn unlink && npm run build && npm run chmod:index && yarn link",

--- a/packages/xstate-compiled/src/printToFile.ts
+++ b/packages/xstate-compiled/src/printToFile.ts
@@ -5,6 +5,7 @@ import helpers from 'handlebars-helpers';
 import path from 'path';
 import { introspectMachine, SubState } from './introspectMachine';
 import pkgUp from 'pkg-up';
+import rimraf from 'rimraf';
 
 const ensureFolderExists = (absoluteDir: string) => {
   if (fs.existsSync(absoluteDir)) {
@@ -77,16 +78,7 @@ export const getNodeModulesDir = () => {
     );
   }
 
-  ensureMultipleFoldersExist(path.dirname(packageJson), [
-    'node_modules',
-    '@xstate',
-    'compiled',
-  ]);
-
-  const targetDir = path.resolve(
-    path.dirname(packageJson),
-    'node_modules/@xstate/compiled',
-  );
+  const targetDir = path.resolve(path.dirname(packageJson), 'node_modules');
 
   return targetDir;
 };
@@ -96,7 +88,14 @@ export const printToFile = (
   outDir?: string,
 ) => {
   const files = getDeclarationFileTexts(cache);
-  const targetDir = getNodeModulesDir();
+  const nodeModulesDir = getNodeModulesDir();
+  const targetDir = path.resolve(nodeModulesDir, '@xstate/compiled');
+
+  /** Delete @xstate/compiled directory so that it triggers VSCode to re-check it */
+  rimraf.sync(path.join(targetDir, '*.d.ts'));
+
+  printJsFiles();
+  ensureMultipleFoldersExist(nodeModulesDir, ['@xstate', 'compiled']);
 
   fs.writeFileSync(
     outDir
@@ -125,7 +124,11 @@ export const printToFile = (
  * to statically analyse
  */
 export const printJsFiles = () => {
-  const targetDir = getNodeModulesDir();
+  const nodeModulesDir = getNodeModulesDir();
+  const targetDir = path.resolve(nodeModulesDir, '@xstate/compiled');
+
+  ensureMultipleFoldersExist(nodeModulesDir, ['@xstate', 'compiled']);
+
   const indexJsTemplate = fs
     .readFileSync(path.resolve(__dirname, './templates/index.js.hbs'))
     .toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@
   resolved "https://registry.yarnpkg.com/@types/gaze/-/gaze-1.1.0.tgz#21d800688eba9f5fab955648b7946083c0074a9b"
   integrity sha512-mKGZISSwlqFOCfYBpnOhVSf0LC8Kr/q0r5wXwWz40V0ChnSC6N61LGdbFAxphUQqaqoiwkM7XzBMKbzdiuWXSg==
 
-"@types/glob@^7.1.3":
+"@types/glob@*", "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
   integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
@@ -1029,6 +1029,14 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
+    "@types/node" "*"
+
+"@types/rimraf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
+  dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/semver@^6.0.0":
@@ -3528,7 +3536,7 @@ jest@^26.4.0:
     import-local "^3.0.2"
     jest-cli "^26.4.0"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3802,6 +3810,13 @@ logging-helpers@^1.0.0:
   dependencies:
     isobject "^3.0.0"
     log-utils "^0.2.1"
+
+loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -4081,6 +4096,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -4379,6 +4399,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -4412,10 +4441,19 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-react-is@^16.12.0:
+react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^3.0.0:
   version "3.0.0"
@@ -4618,7 +4656,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
This is a big one - this weird little trick massively improves the experience of using xstate-codegen no end - type changes are near-instant instead of glacially slow.