### PR TITLE
Fixed withConfig and interpret

### DIFF
--- a/.changeset/two-seals-arrive.md
+++ b/.changeset/two-seals-arrive.md
@@ -2,4 +2,4 @@
 'xstate-codegen': patch
 ---
 
-Fixed a bug where it appeared that the interpret function required two arguments.
+Fixed a bug where the second argument of interpret was being typed incorrectly.

--- a/.changeset/two-seals-arrive.md
+++ b/.changeset/two-seals-arrive.md
@@ -2,4 +2,4 @@
 'xstate-codegen': patch
 ---
 
-Removed the second argument from interpret from the types
+Fixed a bug where it appeared that the interpret function required two arguments.

--- a/.changeset/two-seals-arrive.md
+++ b/.changeset/two-seals-arrive.md
@@ -1,0 +1,5 @@
+---
+'xstate-codegen': patch
+---
+
+Removed the second argument from interpret from the types

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [mattpocock]

--- a/packages/xstate-compiled/examples/createMachineOptions.machine.ts
+++ b/packages/xstate-compiled/examples/createMachineOptions.machine.ts
@@ -1,4 +1,5 @@
 import { createMachine, interpret } from '@xstate/compiled';
+import { useMachine } from '@xstate/compiled/react';
 
 interface Context {}
 
@@ -50,17 +51,18 @@ const machine = createMachine<Context, Event, 'createMachineOptions'>(
   },
 );
 
-interpret(machine, {
-  actions: {
-    requiredAction: () => {},
-  },
-  services: {
-    requiredService: async () => {},
-  },
-  activities: {
-    requiredActivity: () => {},
-  },
-  guards: {
-    requiredCond: () => true,
-  },
-});
+const useOptions = () =>
+  useMachine(machine, {
+    actions: {
+      requiredAction: () => {},
+    },
+    services: {
+      requiredService: async () => {},
+    },
+    activities: {
+      requiredActivity: () => {},
+    },
+    guards: {
+      requiredCond: () => true,
+    },
+  });

--- a/packages/xstate-compiled/examples/fetchMachine-optionalActions.machine.ts
+++ b/packages/xstate-compiled/examples/fetchMachine-optionalActions.machine.ts
@@ -1,4 +1,5 @@
 import { Machine, interpret } from '@xstate/compiled';
+import { useMachine } from '@xstate/compiled/react';
 
 type Data = {
   yeah: boolean;
@@ -44,12 +45,18 @@ const machine = Machine<Context, Event, 'fetchMachineOptionalActions'>(
   },
 );
 
-interpret(machine, {
-  services: {
-    makeFetch: () => {
-      return Promise.resolve({
-        yeah: true,
-      });
+const useOptions = () =>
+  useMachine(machine, {
+    actions: {
+      celebrate: (context, event) => {
+        console.log(event.data);
+      },
     },
-  },
-});
+    services: {
+      makeFetch: () => {
+        return Promise.resolve({
+          yeah: true,
+        });
+      },
+    },
+  });

--- a/packages/xstate-compiled/examples/fetchMachine-optionalServices.machine.ts
+++ b/packages/xstate-compiled/examples/fetchMachine-optionalServices.machine.ts
@@ -1,4 +1,5 @@
 import { Machine, interpret } from '@xstate/compiled';
+import { useMachine } from '@xstate/compiled/react';
 
 type Data = {
   yeah: boolean;
@@ -46,10 +47,11 @@ const machine = Machine<Context, Event, 'fetchMachineOptionalServices'>(
   },
 );
 
-interpret(machine, {
-  actions: {
-    celebrate: (context, event) => {
-      console.log(event.data);
+const useOptions = () =>
+  useMachine(machine, {
+    actions: {
+      celebrate: (context, event) => {
+        console.log(event.data);
+      },
     },
-  },
-});
+  });

--- a/packages/xstate-compiled/examples/fetchMachine.machine.ts
+++ b/packages/xstate-compiled/examples/fetchMachine.machine.ts
@@ -35,17 +35,19 @@ const machine = Machine<Context, Event, 'fetchMachine'>({
   },
 });
 
-interpret(machine, {
-  services: {
-    makeFetch: () => {
-      return Promise.resolve({
-        yeah: true,
-      });
+interpret(
+  machine.withConfig({
+    services: {
+      makeFetch: () => {
+        return Promise.resolve({
+          yeah: true,
+        });
+      },
     },
-  },
-  actions: {
-    celebrate: (context, event) => {
-      console.log(event.data);
+    actions: {
+      celebrate: (context, event) => {
+        console.log(event.data);
+      },
     },
-  },
-});
+  }),
+);

--- a/packages/xstate-compiled/examples/nonRequiredOptions.machine.ts
+++ b/packages/xstate-compiled/examples/nonRequiredOptions.machine.ts
@@ -44,4 +44,4 @@ const machine = Machine<Context, Event, 'nonRequiredOptionsMachine'>(
   },
 );
 
-interpret(machine, {});
+interpret(machine);

--- a/packages/xstate-compiled/examples/options.machine.ts
+++ b/packages/xstate-compiled/examples/options.machine.ts
@@ -1,4 +1,5 @@
 import { Machine, interpret } from '@xstate/compiled';
+import { useMachine } from '@xstate/compiled/react';
 
 interface Context {}
 
@@ -50,17 +51,18 @@ const machine = Machine<Context, Event, 'optionsMachine'>(
   },
 );
 
-interpret(machine, {
-  actions: {
-    requiredAction: () => {},
-  },
-  services: {
-    requiredService: async () => {},
-  },
-  activities: {
-    requiredActivity: () => {},
-  },
-  guards: {
-    requiredCond: () => true,
-  },
-});
+const useOptions = () =>
+  useMachine(machine, {
+    actions: {
+      requiredAction: () => {},
+    },
+    services: {
+      requiredService: async () => {},
+    },
+    activities: {
+      requiredActivity: () => {},
+    },
+    guards: {
+      requiredCond: () => true,
+    },
+  });

--- a/packages/xstate-compiled/examples/rootTransitionTargets.machine.ts
+++ b/packages/xstate-compiled/examples/rootTransitionTargets.machine.ts
@@ -16,4 +16,4 @@ const machine = Machine<
   },
 });
 
-const service = interpret(machine, {});
+const service = interpret(machine);

--- a/packages/xstate-compiled/examples/trafficLightMachine.machine.ts
+++ b/packages/xstate-compiled/examples/trafficLightMachine.machine.ts
@@ -82,14 +82,16 @@ const useTrafficLightMachine = () => {
 const interpretTrafficLightMachine = () => {
   // We use interpretCompiled instead of
   // interpret to avoid function overload problems
-  const interpreter = interpret(lightMachine, {
-    guards: {
-      isSuperCool: (context, event) => {
-        // Note that the event here is typed exactly
-        // to where the guard is used.
-        return event.duration === 0 && context.elapsed > 0;
+  const interpreter = interpret(
+    lightMachine.withConfig({
+      guards: {
+        isSuperCool: (context, event) => {
+          // Note that the event here is typed exactly
+          // to where the guard is used.
+          return event.duration === 0 && context.elapsed > 0;
+        },
       },
-    },
-  });
+    }),
+  );
   return interpreter;
 };

--- a/packages/xstate-compiled/examples/withConfig.machine.ts
+++ b/packages/xstate-compiled/examples/withConfig.machine.ts
@@ -1,0 +1,50 @@
+import { Machine, interpret } from '@xstate/compiled';
+
+type Data = {
+  yeah: boolean;
+};
+
+interface Context {
+  data: Data;
+}
+
+type Event =
+  | { type: 'MAKE_FETCH'; params: { id: string } }
+  | { type: 'CANCEL' }
+  | { type: 'done.invoke.makeFetch'; data: Data };
+
+const machine = Machine<Context, Event, 'withConfigTest'>({
+  initial: 'idle',
+  states: {
+    idle: {
+      on: {
+        MAKE_FETCH: 'pending',
+      },
+    },
+    pending: {
+      invoke: [
+        {
+          src: 'makeFetch',
+          onDone: 'success',
+        },
+      ],
+    },
+    success: {
+      entry: ['celebrate'],
+    },
+  },
+});
+
+/**
+ * withConfig is a partial of the full options
+ */
+machine.withConfig({
+  actions: {
+    // @ts-expect-error
+    wrongActionName: () => {},
+  },
+  services: {
+    // @ts-expect-error
+    wrongServiceName: () => {},
+  },
+});

--- a/packages/xstate-compiled/src/templates/index.d.ts.hbs
+++ b/packages/xstate-compiled/src/templates/index.d.ts.hbs
@@ -268,10 +268,6 @@ declare module '@xstate/compiled' {
     Id extends keyof RegisteredMachinesMap<TContext, TEvent>
   >(
     machine: Extract<RegisteredMachine<TContext, TEvent>, { id: Id }>,
-    options: Extract<
-      RegisteredMachine<TContext, TEvent>,
-      { id: Id }
-    >['_options'],
   ): InterpreterWithMatches<TContext, TSchema, TEvent, Id>;
 
   export function Machine<

--- a/packages/xstate-compiled/src/templates/index.d.ts.hbs
+++ b/packages/xstate-compiled/src/templates/index.d.ts.hbs
@@ -20,6 +20,7 @@ import {
   assign,
   send,
   Expr,
+  InterpreterOptions,
 } from 'xstate';
 import {
   StateWithMatches,
@@ -268,6 +269,7 @@ declare module '@xstate/compiled' {
     Id extends keyof RegisteredMachinesMap<TContext, TEvent>
   >(
     machine: Extract<RegisteredMachine<TContext, TEvent>, { id: Id }>,
+    options?: Partial<InterpreterOptions>
   ): InterpreterWithMatches<TContext, TSchema, TEvent, Id>;
 
   export function Machine<

--- a/packages/xstate-compiled/src/templates/index.d.ts.hbs
+++ b/packages/xstate-compiled/src/templates/index.d.ts.hbs
@@ -140,6 +140,13 @@ declare module '@xstate/compiled' {
       devTools?: boolean;
     };
     _subState: {{{this.machine.subState}}};
+    withConfig(
+      options: TwoLevelPartial<{{capitalize this.id}}StateMachine<
+        TContext,
+        TEvent,
+        '{{ this.id }}'
+      >['_options']>
+    ): this;
   }
   {{/each}}
 


### PR DESCRIPTION
Fixes #31 and fixes #32

Some notes: I couldn't get it to be strongly typed - I could only make it a partial of the options that the machine can receive. This is because we are inheriting from the XState StateNode class, and I can't override it to be stricter than what withConfig can by default receive. Open to ideas here.

I'm also not sure whether we actually want withConfig to be _strongly_ typed so all pieces of it are required, since it's by definition composable.