### PR TITLE
Zero exit code when no files matching

### DIFF
--- a/packages/xstate-compiled/src/index.ts
+++ b/packages/xstate-compiled/src/index.ts
@@ -58,7 +58,7 @@ gaze(pattern, {}, async function(err, watcher) {
 
   if (filteredFiles.length === 0) {
     console.log('No files found from that glob');
-    process.exit(1);
+    process.exit(0);
   }
 
   printJsFiles();


### PR DESCRIPTION
No matching files shouldn't be considered an error. It's a problem in CI where some files are not available yet (due to Docker layering optimizations) and it would fail the build.

So far I've been dealing with that using `--ignore-scripts` flag. However, now I also need to run `patch-package` in `postinstall` so it's no longer an option. 