### PR TITLE
Add failing example for choose action

### DIFF
--- a/packages/xstate-compiled/examples/chooseAction.machine.ts
+++ b/packages/xstate-compiled/examples/chooseAction.machine.ts
@@ -1,0 +1,41 @@
+import { Machine, actions } from '@xstate/compiled';
+
+interface Context {}
+
+type Event = { type: 'SOME_EVENT' } | { type: 'ANOTHER_EVENT' };
+
+/**
+ * An example machine using the `choose` action
+ */
+const machine = Machine<Context, Event, 'chooseMachine'>({
+  initial: 'idle',
+  states: {
+    idle: {
+      on: {
+        SOME_EVENT: {
+          actions: actions.choose([
+            { cond: 'guardA', actions: ['actionA', 'actionB'] },
+            { cond: 'guardB', actions: ['actionB'] },
+            { actions: 'actionC' }
+          ])
+        },
+        ANOTHER_EVENT: {
+          cond: 'guardC',
+          actions: 'actionD',
+        }
+      },
+    },
+  },
+}, {
+  guards: {
+    guardA: (context, event) => false,
+    guardB: (context, event) => true,
+    guardC: (context, event) => true,
+  },
+  actions: {
+    actionA: (context, event) => {},
+    actionB: (context, event) => {},
+    actionC: (context, event) => {},
+    actionD: (context, event) => {},
+  },
+});


### PR DESCRIPTION
As mentioned in https://github.com/mattpocock/xstate-codegen/issues/61 here is an example of the `choose` action.

In the `guards` we see this error:

```
Object literal may only specify known properties, but 'guardA' does not exist in type 'Partial<{ guardC?: ((context: Context, event: { type: "ANOTHER_EVENT"; }) => boolean) | undefined; }>'. Did you mean to write 'guardC'?
```

And in the the `actions` we see a similar error:

```
Object literal may only specify known properties, but 'actionA' does not exist in type 'Partial<{ actionD?: ActionObject<Context, { type: "ANOTHER_EVENT"; }> | ActionFunction<Context, { type: "ANOTHER_EVENT"; }> | undefined; }>'. Did you mean to write 'actionD'?
```