### PR TITLE
Fix issue with space in action/guard/etc. name

### DIFF
--- a/.changeset/purple-melons-fetch.md
+++ b/.changeset/purple-melons-fetch.md
@@ -1,0 +1,5 @@
+---
+'xstate-codegen': patch
+---
+
+Fix issue with space in action/guard/etc. name

--- a/packages/xstate-compiled/src/templates/index.d.ts.hbs
+++ b/packages/xstate-compiled/src/templates/index.d.ts.hbs
@@ -58,7 +58,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.guards}}
       guards{{#unless this.machine.guards.required}}?{{/unless}}: {
         {{#each this.machine.guards.lines}}
-        "{{this.name}}"{{#unless this.required}}?{{/unless}}: (
+        '{{this.name}}'{{#unless this.required}}?{{/unless}}: (
           context: TContext,
             {{#if this.events}}
           event:
@@ -75,7 +75,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.actions}}
       actions{{#unless this.machine.actions.required}}?{{/unless}}: {  
         {{#each this.machine.actions.lines}}
-          "{{this.name}}"{{#unless this.required}}?{{/unless}}:
+          '{{this.name}}'{{#unless this.required}}?{{/unless}}:
             | ActionObject<
                 TContext,
                 {{#if this.events}}
@@ -114,7 +114,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.services}}
       services{{#unless this.machine.services.required}}?{{/unless}}: {
         {{#each this.machine.services.lines}}
-        "{{this.name}}"{{#unless this.required}}?{{/unless}}: InvokeCreator<
+        '{{this.name}}'{{#unless this.required}}?{{/unless}}: InvokeCreator<
           TContext, 
           {{#if this.events}}
           Extract<TEvent,
@@ -135,7 +135,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.activities}}
       activities{{#unless this.machine.activities.required}}?{{/unless}}: {
         {{#each this.machine.activities.lines}}    
-        "{{this.name}}"{{#unless this.required}}?{{/unless}}: ActivityConfig<TContext, TEvent>;
+        '{{this.name}}'{{#unless this.required}}?{{/unless}}: ActivityConfig<TContext, TEvent>;
         {{/each}}
       };
       {{/if}}

--- a/packages/xstate-compiled/src/templates/index.d.ts.hbs
+++ b/packages/xstate-compiled/src/templates/index.d.ts.hbs
@@ -58,7 +58,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.guards}}
       guards{{#unless this.machine.guards.required}}?{{/unless}}: {
         {{#each this.machine.guards.lines}}
-        {{this.name}}{{#unless this.required}}?{{/unless}}: (
+        "{{this.name}}"{{#unless this.required}}?{{/unless}}: (
           context: TContext,
             {{#if this.events}}
           event:
@@ -75,7 +75,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.actions}}
       actions{{#unless this.machine.actions.required}}?{{/unless}}: {  
         {{#each this.machine.actions.lines}}
-          {{this.name}}{{#unless this.required}}?{{/unless}}:
+          "{{this.name}}"{{#unless this.required}}?{{/unless}}:
             | ActionObject<
                 TContext,
                 {{#if this.events}}
@@ -114,7 +114,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.services}}
       services{{#unless this.machine.services.required}}?{{/unless}}: {
         {{#each this.machine.services.lines}}
-        {{this.name}}{{#unless this.required}}?{{/unless}}: InvokeCreator<
+        "{{this.name}}"{{#unless this.required}}?{{/unless}}: InvokeCreator<
           TContext, 
           {{#if this.events}}
           Extract<TEvent,
@@ -135,7 +135,7 @@ declare module '@xstate/compiled' {
       {{#if this.machine.activities}}
       activities{{#unless this.machine.activities.required}}?{{/unless}}: {
         {{#each this.machine.activities.lines}}    
-        {{this.name}}{{#unless this.required}}?{{/unless}}: ActivityConfig<TContext, TEvent>;
+        "{{this.name}}"{{#unless this.required}}?{{/unless}}: ActivityConfig<TContext, TEvent>;
         {{/each}}
       };
       {{/if}}


### PR DESCRIPTION
Fixes an issue whereby a space in the key name for an action, activity, guard, or service causes a failure. We do this by wrapping the name of those items in "quotes" in the output. This is achieved by editing the template file.